### PR TITLE
fixed response being the string representation of a bytes array instead of a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,7 @@ from srcds.rcon import RconConnection
 
 conn = RconConnection('127.0.0.1', port=27015, password='password')
 response = conn.exec_command('status')
-# Response content can be accessed via str(response) or response.body
-# Response content will be a utf-8 encoded string in most cases, but it may depend on the
+# Response will be a utf-8 encoded string in most cases, but it may depend on the
 # server type.
 
 # For servers that do not support multipart RCON responses like factorio,

--- a/srcds/rcon.py
+++ b/srcds/rcon.py
@@ -155,7 +155,7 @@ class RconConnection(object):
         # Read and ignore the extra empty body response
         self._recv_pkt()
         return RconPacket(req_pkt.pkt_id, SERVERDATA_RESPONSE_VALUE,
-                          ''.join(str(body_parts)))
+                          ''.join([x.decode("UTF-8") for x in body_parts]))
 
 
 class RconError(Exception):


### PR DESCRIPTION
Currently, the `exec_command` function returns a string (contrary to the README). This string contains the `__str__` representation of an array containing a byte sequence.

Current output:
```python
print(response)
=> [b'----- Recently Disconnected Players [Max of 15] -----\x00\x00']
print(repr(response))
=> "[b'----- Recently Disconnected Players [Max of 15] -----\\x00\\x00']"
```
Guilty lines of code:
```python
body_parts = []
while True:
    [...]
    body_parts.append(response.body)
[...]
return RconPacket(req_pkt.pkt_id, SERVERDATA_RESPONSE_VALUE,
                    ''.join(str(body_parts)))
```
As you can see, instead of joining the elements of `body_parts`, `body_parts` itself is converted into a string, resulting in the final output being a string representation of an array instead of the actual response content.

Output with my patch:
```python
print(response)
=> ----- Recently Disconnected Players [Max of 15] -----
print(repr(response))
=> '----- Recently Disconnected Players [Max of 15] -----\x00\x00'
```
It might be smart to strip the null-bytes from the response content, since they're part of the RCON protocol. It didn't affect my use case though.